### PR TITLE
1.16.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-minecraft_version = 1.15.2
-forge_version = 31.2.0
+minecraft_version = 1.16.1
+forge_version = 32.0.61
 mcp_mappings_channel = snapshot
-mcp_mappings_version = 20200519-1.15.1
+mcp_mappings_version = 20200514-1.16
 
-mod_version = 1.8.7.21a
+mod_version = 1.8.8.22a

--- a/src/main/java/com/lazynessmind/snad/Snad.java
+++ b/src/main/java/com/lazynessmind/snad/Snad.java
@@ -18,7 +18,7 @@ public class Snad {
     public Snad() {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Configs.COMMON_CONFIG);
 
-        proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> CommonProxy::new);
+        proxy = DistExecutor.safeRunForDist(() -> ClientProxy::new, () -> CommonProxy::new);
         proxy.init();
 
         Configs.load(Configs.COMMON_CONFIG, FMLPaths.CONFIGDIR.get().resolve("snad-common.toml"));

--- a/src/main/java/com/lazynessmind/snad/block/SnadBlock.java
+++ b/src/main/java/com/lazynessmind/snad/block/SnadBlock.java
@@ -30,7 +30,7 @@ public class SnadBlock extends FallingBlock {
     }
 
     @Override
-    public int getDustColor(BlockState state) {
+    public int getDustColor(BlockState state, IBlockReader p_189876_2_, BlockPos p_189876_3_) {
         return this.color;
     }
 
@@ -38,8 +38,8 @@ public class SnadBlock extends FallingBlock {
     @Override
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
         super.tick(state, world, pos, random);
-
-        Block blockAbove = world.getBlockState(pos.up()).getBlock();
+        BlockState blockStateAbove = world.getBlockState(pos.up());
+        Block blockAbove = blockStateAbove.getBlock();
 
         if (blockAbove instanceof SugarCaneBlock || blockAbove instanceof CactusBlock) {
 
@@ -57,7 +57,7 @@ public class SnadBlock extends FallingBlock {
                 isSameBlockType = world.getBlockState(pos.up(height)).getBlock().getClass() == blockAbove.getClass();
             }
         } else if (blockAbove instanceof IPlantable) {
-            blockAbove.randomTick(world.getBlockState(pos.up()), world, pos.up(), random);
+            blockStateAbove.randomTick(world, pos.up(), random);
         }
     }
 
@@ -66,20 +66,19 @@ public class SnadBlock extends FallingBlock {
         final BlockPos plantPos = new BlockPos(pos.getX(), pos.getY() + 1, pos.getZ());
         final PlantType plantType = iPlantable.getPlantType(blockReader, plantPos);
 
-        switch (plantType) {
-            case Desert: {
-                return true;
-            }
-            case Water: {
-                return blockReader.getBlockState(pos).getMaterial() == Material.WATER && blockReader.getBlockState(pos) == getDefaultState();
-            }
-            case Beach: {
-                return ((blockReader.getBlockState(pos.east()).getMaterial() == Material.WATER || blockReader.getBlockState(pos.east()).has(BlockStateProperties.WATERLOGGED))
-                        || (blockReader.getBlockState(pos.west()).getMaterial() == Material.WATER || blockReader.getBlockState(pos.west()).has(BlockStateProperties.WATERLOGGED))
-                        || (blockReader.getBlockState(pos.north()).getMaterial() == Material.WATER || blockReader.getBlockState(pos.north()).has(BlockStateProperties.WATERLOGGED))
-                        || (blockReader.getBlockState(pos.south()).getMaterial() == Material.WATER || blockReader.getBlockState(pos.south()).has(BlockStateProperties.WATERLOGGED)));
-            }
+        if (PlantType.DESERT.equals(plantType)) {
+            return true;
+        } else if (PlantType.WATER.equals(plantType)) {
+            return blockReader.getBlockState(pos).getMaterial() == Material.WATER && blockReader.getBlockState(pos) == getDefaultState();
+        } else if (PlantType.BEACH.equals(plantType)) {
+            return checkIfWater(blockReader, pos.east()) || checkIfWater(blockReader, pos.west()) || checkIfWater(blockReader, pos.north()) || checkIfWater(blockReader, pos.south());
         }
         return false;
+    }
+
+    // Checks if the given position is a water block or has the Waterlogged property and that property is true
+    private boolean checkIfWater(IBlockReader blockReader, BlockPos pos)
+    {
+        return blockReader.getBlockState(pos).getMaterial() == Material.WATER || (blockReader.getBlockState(pos).getValues().containsKey(BlockStateProperties.WATERLOGGED) && blockReader.getBlockState(pos).get(BlockStateProperties.WATERLOGGED));
     }
 }

--- a/src/main/java/com/lazynessmind/snad/block/SnadBlock.java
+++ b/src/main/java/com/lazynessmind/snad/block/SnadBlock.java
@@ -50,7 +50,7 @@ public class SnadBlock extends FallingBlock {
             while (isSameBlockType) {
                 for (int i = 0; i < Configs.SPEED_INCREASE_DEFAULT_VALUE.get(); i++) {
                     if (i == 0 | canSustainPlant(world.getBlockState(pos), world, pos, null, (IPlantable) blockAbove)) {
-                        world.getBlockState(pos.up(height)).getBlock().randomTick(world.getBlockState(pos.up(height)), world, pos.up(height), random);
+                        world.getBlockState(pos.up(height)).randomTick(world, pos.up(height), random);
                     }
                 }
                 height++;

--- a/src/main/java/com/lazynessmind/snad/proxy/CommonProxy.java
+++ b/src/main/java/com/lazynessmind/snad/proxy/CommonProxy.java
@@ -12,8 +12,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class CommonProxy {
 
-    public static DeferredRegister<Block> BLOCKS = new DeferredRegister<Block>(ForgeRegistries.BLOCKS, Snad.MODID);
-    public static DeferredRegister<Item> ITEMS = new DeferredRegister<Item>(ForgeRegistries.ITEMS, Snad.MODID);
+    public static DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, Snad.MODID);
+    public static DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, Snad.MODID);
     public static RegistryObject<SnadBlock> SNAD_BLOCK = BLOCKS.register("snad", () -> new SnadBlock("snad", -2370656, MaterialColor.SAND));
     public static RegistryObject<SnadBlock> RED_SNAD_BLOCK = BLOCKS.register("red_snad", () -> new SnadBlock("red_snad", -5679071, MaterialColor.ADOBE));
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ loaderVersion="[31,)"
 issueTrackerURL="https://github.com/lazynessmind/Snad/issues"
 [[mods]]
 modId="snad"
-version="1.8.7.21a"
+version="1.8.8.22a"
 displayName="Snad"
 credits="TheRoBrit (Original mod)"
 authors="lazynessmind (me), TheRoBrit"


### PR DESCRIPTION
Update Snad to 1.16.1
- Update `gradle.properties`
- Use `BlockState` to tick the plant above the Snad block, as calling the `randomTick` method to a Block instance is deprecated
- Update method used to check if there is water next to the Snad block
- Update `getDustColor()` method
- Deferred Registers are now created with the .create() method
- Use `DistExecutor.safeRunForDist` instead of `DistExecutor.runForDist` (I don't really know the difference, but `DistExecutor.runForDist` is deprecated)
- Change mod version in `mods.toml`

Notes:
- `SnadBlock` still overwrites the `randomTick` method, which has been deprecated (for use in `Block`, not in `BlockState`)
- I found this thread [https://forums.minecraftforge.net/topic/87835-solved-update-block-every-tick-for-grass-like-spreading/?tab=comments#comment-410841](https://forums.minecraftforge.net/topic/87835-solved-update-block-every-tick-for-grass-like-spreading/?tab=comments#comment-410841) on the Minecraft Forums which addresses this
- You might also want to create a new branch instead of merging this Pull Request into the 1.15.2 branch

Edit:
- I just realized that I don't quite know how all the version numbers are decided for this project. I chose 1.8.8.22a but that doesn't really represent the build number, so let me know what version number I should change it to.